### PR TITLE
数字表示部分のTextFieldをTextに変更

### DIFF
--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
@@ -1,6 +1,7 @@
 package com.example.tutorialcounterapp.counter_screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
@@ -71,7 +73,7 @@ fun CounterScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 10.dp, vertical = 15.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ){
             IconButton(onClick = { onDeleteClicked() }) {
                 Icon(
@@ -103,10 +105,12 @@ fun CounterScreen(
                 modifier = Modifier.weight(1f)
             ){
                 var text by remember { mutableStateOf("") }
-                OutlinedTextField(
-                    value = text,
-                    onValueChange = { text = it },
-                    modifier = Modifier.padding(20.dp)
+                Text(
+                    text = text,
+                    modifier = Modifier
+                        .padding(start = 12.dp)
+                        .size(56.dp)
+                        .border(1.dp, Color.Gray, shape = RoundedCornerShape(4.dp))
                 )
             }
 


### PR DESCRIPTION
## やったことの概要(必須)
カウント表示部の実装をTextFieldからTextに置き換え

## 詳細(必須)
カウントはユーザーが直接入力するものではないため、TextFieldではなく表示するだけのTextが適切。
UIは大体同じになるようにしたが、もしかすると画面比率などが違う端末では崩れる可能性があるので、その場合は対処が必要。

## 影響範囲(必須)
端末によっては画面のUIが崩れる可能性あり。

## UIに関するものはスクリーンショットを貼る
![image](https://github.com/user-attachments/assets/c65562a3-499a-4c2f-9d03-e8bc999fa3ba)

## 補足


