### PR TITLE
Feat/navigation kosei

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-
+    val nav_version = "2.8.0"
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("androidx.navigation:navigation-compose:$nav_version")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/tutorialcounterapp/MainActivity.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/MainActivity.kt
@@ -11,7 +11,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.tutorialcounterapp.counter_screen.CounterScreen
+import com.example.tutorialcounterapp.setting_screen.SettingScreen
 import com.example.tutorialcounterapp.ui.theme.TutorialCounterAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,7 +25,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             TutorialCounterAppTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    CounterScreen(modifier = Modifier.padding(innerPadding))
+                    val navController = rememberNavController()
+                    NavHost(navController = navController, startDestination = "Counter", modifier = Modifier.padding(innerPadding)){
+                        composable("Counter") { CounterScreen(onSettingClicked = {navController.navigate(route = "Setting")})}
+                        composable("Setting") { SettingScreen()}
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/tutorialcounterapp/setting_screen/SettingScreen.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/setting_screen/SettingScreen.kt
@@ -1,0 +1,12 @@
+package com.example.tutorialcounterapp.setting_screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SettingScreen(
+    modifier: Modifier = Modifier
+){
+
+}
+


### PR DESCRIPTION
## やったことの概要(必須)
SettingScreenの作成と画面遷移

## 詳細(必須)
Navigationを用いて設定アイコンを押すと設定画面に遷移できるようにした。
戻れはしません。

## 影響範囲(必須)
設定アイコンを押したときの挙動

## UIに関するものはスクリーンショットを貼る

## 補足
