### PR TITLE
feat/save_items_kosei

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-09-24T02:14:37.150821500Z">
+        <DropdownSelection timestamp="2024-10-12T05:32:11.651231300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\ID-No\.android\avd\Pixel_8_Pro_API_35_1.avd" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation("androidx.navigation:navigation-compose:$nav_version")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:name=".counter_screen.MyApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.TutorialCounterApp"

--- a/app/src/main/java/com/example/tutorialcounterapp/MainActivity.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/MainActivity.kt
@@ -7,10 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController

--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.tutorialcounterapp.R
 import com.example.tutorialcounterapp.ui.theme.TutorialCounterAppTheme
@@ -120,7 +119,7 @@ fun CounterScreen(
             Box(
                 modifier = Modifier.weight(1f)
             ){
-                var text by remember { mutableStateOf("") }
+                val text by remember { mutableStateOf("") }
                 Text(
                     text = text,
                     modifier = Modifier

--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,9 +92,12 @@ fun CounterScreen(
             Box(
                 modifier = Modifier.weight(2f)
             ){
-                var text by remember { mutableStateOf("") }
+                var text by remember { mutableStateOf(savedItems.itemNameSet.firstOrNull() ?:"") }
                 var itemSet by remember {
                     mutableStateOf(savedItems.itemNameSet)
+                }
+                LaunchedEffect(savedItems.itemNameSet) {
+                    text = savedItems.itemNameSet.firstOrNull() ?: ""
                 }
                 OutlinedTextField(
                     value = text,

--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,18 +27,23 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.tutorialcounterapp.R
 import com.example.tutorialcounterapp.ui.theme.TutorialCounterAppTheme
 
 @Composable
 fun CounterScreen(
     modifier: Modifier = Modifier,
+    myAppViewModel: CounterScreenViewModel = viewModel(factory = CounterScreenViewModel.Factory),
     onSettingClicked: () -> Unit = {},
     onDeleteClicked: () -> Unit = {},
     onDecrementClicked: () -> Unit = {},
     onIncrementClicked: () -> Unit = {},
     onAddClicked: () -> Unit = {},
 ) {
+    val savedItems by myAppViewModel.uiState.collectAsState()
+
     Column(
         modifier = Modifier
             .then(modifier),
@@ -86,9 +92,15 @@ fun CounterScreen(
                 modifier = Modifier.weight(2f)
             ){
                 var text by remember { mutableStateOf("") }
+                var itemSet by remember {
+                    mutableStateOf(savedItems.itemNameSet)
+                }
                 OutlinedTextField(
                     value = text,
-                    onValueChange = { text = it },
+                    onValueChange = {
+                        text = it
+                        itemSet = setOf(it)
+                        myAppViewModel.saveItems(itemSet)},
                     modifier = Modifier.padding(20.dp)
                 )
             }

--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreenUiState.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreenUiState.kt
@@ -1,5 +1,24 @@
 package com.example.tutorialcounterapp.counter_screen
 
+import android.app.Application
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.example.tutorialcounterapp.data.UserRepository
+
 data class CounterScreenUiState(
     val itemNameSet: Set<String> = emptySet(),
 )
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "setting"
+)
+
+class MyApplication: Application() {
+    lateinit var userRepository: UserRepository
+    override fun onCreate() {
+        super.onCreate()
+        userRepository = UserRepository(dataStore)
+    }
+}

--- a/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreenViewModel.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/counter_screen/CounterScreenViewModel.kt
@@ -1,12 +1,45 @@
 package com.example.tutorialcounterapp.counter_screen
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.tutorialcounterapp.data.UserRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
-class CounterScreenViewModel: ViewModel() {
+class CounterScreenViewModel(private val userRepository: UserRepository): ViewModel() {
 
+    val uiState: StateFlow<CounterScreenUiState> =
+        userRepository.currentItems.map { itemNameSet ->
+            CounterScreenUiState(itemNameSet)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = CounterScreenUiState()
+        )
 
     // TODO: fun saveItems(items: Set<String>) の実装(アイテム名のリストを保存する)
 
+    fun saveItems(items: Set<String>){
+        viewModelScope.launch {
+            userRepository.saveItems(items)
+        }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val application = (this[APPLICATION_KEY] as MyApplication)
+                CounterScreenViewModel(application.userRepository)
+            }
+        }
+    }
 
     // TODO: fun saveCountValue(itemName: String, countValue: Int) の実装(アイテム名をキーとしてカウント値を保存する)
 

--- a/app/src/main/java/com/example/tutorialcounterapp/data/UserRepository.kt
+++ b/app/src/main/java/com/example/tutorialcounterapp/data/UserRepository.kt
@@ -1,0 +1,25 @@
+package com.example.tutorialcounterapp.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class UserRepository(private val dataStore: DataStore<Preferences>) {
+
+    private object PreferenceKeys {
+        val ITEMS = stringSetPreferencesKey("items")
+    }
+    val currentItems: Flow<Set<String>> =
+        dataStore.data.map { preferences ->
+            preferences[PreferenceKeys.ITEMS] ?: emptySet()
+        }
+
+    suspend fun saveItems(items: Set<String>){
+        dataStore.edit{ preferences ->
+            preferences[PreferenceKeys.ITEMS] = items
+        }
+    }
+}


### PR DESCRIPTION
## やったことの概要(必須)
アイテムのリストの保存の実装

## 詳細(必須)
エミュレータ上でアプリを終了したあとに再び起動し、その前に入力していたアイテム名が保持されるようになったことを確認しました。
数に関しては全く手をつけていません。
アイテムの追加、削除もできません。

## 影響範囲(必須)
OutlinedTextFieldの表示

## UIに関するものはスクリーンショットを貼る

## 補足
入力時の挙動がカクつくようになりました。